### PR TITLE
Allow laravel 5.1 installs by lowering the symfony/process requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "laravel/framework": "^5.1",
-        "symfony/process": "2.8.*|3.0.*",
+        "symfony/process": ">=2.7.*",
         "phpunit/phpunit-selenium": ">=1.2"
     },
     "autoload": {


### PR DESCRIPTION
Change composer.json file to lower the symfony process requirement to allow installation on 5.1
