### PR TITLE
Fixing bug with allowing 5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "laravel/framework": "^5.1",
-        "symfony/process": ">=2.7.*",
+        "symfony/process": ">=2.7",
         "phpunit/phpunit-selenium": ">=1.2"
     },
     "autoload": {


### PR DESCRIPTION
composer doesn't recognize wildcards in >= constraint
