### PR TITLE
Provides separate methods for typing in fields with different selector types

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -31,6 +31,6 @@
         <env name="CACHE_DRIVER" value="array"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="QUEUE_DRIVER" value="sync"/>
-        <env name="APP_URL" value="http://127.0.0.1"/>
+        <env name="APP_URL" value="http://127.0.0.1:5000"/>
     </php>
 </phpunit>

--- a/src/Services/InteractWithPage.php
+++ b/src/Services/InteractWithPage.php
@@ -126,7 +126,7 @@ trait InteractWithPage
     }
 
     /**
-     * Abstraction for typing into a field with a specific selector type
+     * Abstraction for typing into a field with a specific selector type.
      * 
      * @param $type - one of 'Name', 'Id', 'CssSelector'
      * @param $value - value to enter into form element
@@ -138,14 +138,14 @@ trait InteractWithPage
     private function typeBySelectorType($type, $value, $name, $clear = false)
     {
         try {
-            $element = $this->{'by' . $type}($name);
+            $element = $this->{'by'.$type}($name);
             if ($clear) {
                 $element->clear();
             }
 
             $element->value($value);
         } catch (\Exception $e) {
-            throw new CannotFindElement('Could not find element with ' . $type . ' of ' . $name);
+            throw new CannotFindElement('Could not find element with '.$type.' of '.$name);
         }
 
         return $this;

--- a/src/Services/InteractWithPage.php
+++ b/src/Services/InteractWithPage.php
@@ -127,7 +127,7 @@ trait InteractWithPage
 
     /**
      * Abstraction for typing into a field with a specific selector type.
-     * 
+     *
      * @param $type - one of 'Name', 'Id', 'CssSelector'
      * @param $value - value to enter into form element
      * @param $name - value to use for the selector $type

--- a/src/Services/InteractWithPage.php
+++ b/src/Services/InteractWithPage.php
@@ -126,6 +126,74 @@ trait InteractWithPage
     }
 
     /**
+     * Abstraction for typing into a field with a specific selector type
+     * 
+     * @param $type - one of 'Name', 'Id', 'CssSelector'
+     * @param $value - value to enter into form element
+     * @param $name - value to use for the selector $type
+     * @param bool $clear - Whether or not to clear the input first on say an edit form
+     *
+     * @return $this
+     */
+    private function typeBySelectorType($type, $value, $name, $clear = false)
+    {
+        try {
+            $element = $this->{'by' . $type}($name);
+            if ($clear) {
+                $element->clear();
+            }
+
+            $element->value($value);
+        } catch (\Exception $e) {
+            throw new CannotFindElement('Could not find element with ' . $type . ' of ' . $name);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Type a value into a form input by that inputs name.
+     *
+     * @param $value
+     * @param $name
+     * @param bool $clear Whether or not to clear the input first on say an edit form
+     *
+     * @return $this
+     */
+    protected function typeByName($value, $name, $clear = false)
+    {
+        return $this->typeBySelectorType('Name', $value, $name, $clear);
+    }
+
+    /**
+     * Type a value into a form input by that inputs id.
+     *
+     * @param $value
+     * @param $name
+     * @param bool $clear Whether or not to clear the input first on say an edit form
+     *
+     * @return $this
+     */
+    protected function typeById($value, $name, $clear = false)
+    {
+        return $this->typeBySelectorType('Id', $value, $name, $clear);
+    }
+
+    /**
+     * Type a value into a form input by that inputs id.
+     *
+     * @param $value
+     * @param $name
+     * @param bool $clear Whether or not to clear the input first on say an edit form
+     *
+     * @return $this
+     */
+    protected function typeByCssSelector($value, $name, $clear = false)
+    {
+        return $this->typeBySelectorType('CssSelector', $value, $name, $clear);
+    }
+
+    /**
      * Function to type information as an array
      * The key of the array specifies the input name.
      *

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -28,6 +28,27 @@ class FormTest extends TestCase
             ->typeInformation($formInfo);
     }
 
+    public function testItCanTypeByName()
+    {
+        $this->visit('/tests/html/main.html')
+            ->click('Forms')
+            ->typeByName('alice@foo.com', 'inputEmail-name');
+    }
+
+    public function testItCanTypeById()
+    {
+        $this->visit('/tests/html/main.html')
+            ->click('Forms')
+            ->typeById('bob@bar.com', 'inputEmail');
+    }
+
+    public function testItCanTypeByCssSelector()
+    {
+        $this->visit('/tests/html/main.html')
+            ->click('Forms')
+            ->typeByCssSelector('bob@bar.com', '#inputEmail');
+    }
+
     public function testItCanPressAButton()
     {
         $formInfo = [

--- a/tests/html/forms.php
+++ b/tests/html/forms.php
@@ -66,19 +66,19 @@
                             <div class="form-group">
                                 <label class="control-label col-xs-3" for="inputEmail">Email:</label>
                                 <div class="col-xs-9">
-                                    <input type="email" class="form-control" id="inputEmail" name="inputEmail" placeholder="Email">
+                                    <input type="email" class="form-control" id="inputEmail" name="inputEmail-name" placeholder="Email">
                                 </div>
                             </div>
                             <div class="form-group">
                                 <label class="control-label col-xs-3" for="inputPassword">Password:</label>
                                 <div class="col-xs-9">
-                                    <input type="password" class="form-control" id="inputPassword" name="inputPassword" placeholder="Password">
+                                    <input type="password" class="form-control" id="inputPassword" name="inputPassword-name" placeholder="Password">
                                 </div>
                             </div>
                             <div class="form-group">
                                 <label class="control-label col-xs-3" for="confirmPassword">Confirm Password:</label>
                                 <div class="col-xs-9">
-                                    <input type="password" class="form-control" id="confirmPassword" name="confirmPassword" placeholder="Confirm Password">
+                                    <input type="password" class="form-control" id="confirmPassword" name="confirmPassword-name" placeholder="Confirm Password">
                                 </div>
                             </div>
                             <div class="form-group">


### PR DESCRIPTION
As described in issue #26, just using the 'type' method for filling out forms can be quite slow if the attribute you are using for finding the form element is not the id. Given that when you are writing tests, you are going to know what kind of selector you are using, this PR provides new methods for typing in fields that are found with a specific selector type.

So instead of

```$this->type('foo', '#bar');```

you can do

```$this->typeByCssSelector('foo', '#bar')```

the three typing methods are:

- ```typeById```
- ```typeByName```
- ```typeByCssSelector```

I have followed the current approach to the tests to implement basic tests of these methods. These tests don't actually verify that the text is entered into the fields, but I figured that the current approach is considered sufficient (i.e. no exception is being thrown by selenium), and I didn't want to spend a lot of time trying to extend the testing strategy if it's not been necessary up until now.