### PR TITLE
Add --dev flag to composer install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ php artisan add modelizer/selenium
 
 Or you can do it by composer.
 ```php
-composer require modelizer/selenium "~1.0"
+composer require --dev modelizer/selenium "~1.0"
 ```
 
 Register Service provider in `app.php`


### PR DESCRIPTION
This makes it so that the package is only required while developing, not deploying.